### PR TITLE
Refactor: Declarative column-to-CDX field mapping

### DIFF
--- a/src/internet_archive.cpp
+++ b/src/internet_archive.cpp
@@ -494,6 +494,16 @@ static unique_ptr<GlobalTableFunctionState> WaybackMachineInitGlobal(ClientConte
 				bind_data.fields_needed.push_back("length");
 			} else if (col_name == "response") {
 				bind_data.fetch_response = true;
+				// Response fetching requires timestamp and original to construct download URL:
+				// https://web.archive.org/web/{timestamp}id_/{original}
+				if (std::find(bind_data.fields_needed.begin(), bind_data.fields_needed.end(), "timestamp") ==
+				    bind_data.fields_needed.end()) {
+					bind_data.fields_needed.push_back("timestamp");
+				}
+				if (std::find(bind_data.fields_needed.begin(), bind_data.fields_needed.end(), "original") ==
+				    bind_data.fields_needed.end()) {
+					bind_data.fields_needed.push_back("original");
+				}
 				DUCKDB_LOG_DEBUG(context, "Will fetch response bodies");
 			} else if (col_name == "year" || col_name == "month") {
 				// year and month need timestamp field

--- a/src/internet_archive.cpp
+++ b/src/internet_archive.cpp
@@ -23,6 +23,17 @@
 namespace duckdb {
 
 // ========================================
+// HELPERS
+// ========================================
+
+// Add a field to fields_needed if not already present
+static void EnsureFieldNeeded(vector<string> &fields_needed, const string &field) {
+	if (std::find(fields_needed.begin(), fields_needed.end(), field) == fields_needed.end()) {
+		fields_needed.push_back(field);
+	}
+}
+
+// ========================================
 // BIND DATA AND STATE
 // ========================================
 
@@ -496,21 +507,12 @@ static unique_ptr<GlobalTableFunctionState> WaybackMachineInitGlobal(ClientConte
 				bind_data.fetch_response = true;
 				// Response fetching requires timestamp and original to construct download URL:
 				// https://web.archive.org/web/{timestamp}id_/{original}
-				if (std::find(bind_data.fields_needed.begin(), bind_data.fields_needed.end(), "timestamp") ==
-				    bind_data.fields_needed.end()) {
-					bind_data.fields_needed.push_back("timestamp");
-				}
-				if (std::find(bind_data.fields_needed.begin(), bind_data.fields_needed.end(), "original") ==
-				    bind_data.fields_needed.end()) {
-					bind_data.fields_needed.push_back("original");
-				}
+				EnsureFieldNeeded(bind_data.fields_needed, "timestamp");
+				EnsureFieldNeeded(bind_data.fields_needed, "original");
 				DUCKDB_LOG_DEBUG(context, "Will fetch response bodies");
 			} else if (col_name == "year" || col_name == "month") {
 				// year and month need timestamp field
-				if (std::find(bind_data.fields_needed.begin(), bind_data.fields_needed.end(), "timestamp") ==
-				    bind_data.fields_needed.end()) {
-					bind_data.fields_needed.push_back("timestamp");
-				}
+				EnsureFieldNeeded(bind_data.fields_needed, "timestamp");
 			} else if (col_name == "cdx_url") {
 				// cdx_url doesn't need any CDX fields
 			}

--- a/src/internet_archive.cpp
+++ b/src/internet_archive.cpp
@@ -482,8 +482,13 @@ static unique_ptr<GlobalTableFunctionState> WaybackMachineInitGlobal(ClientConte
 	state->column_ids = input.column_ids;
 
 	// Rebuild fields_needed based on projection pushdown
-	// Map column names to CDX API field names
+	// Two-phase approach: detect what's needed, then add dependencies
 	bind_data.fields_needed.clear();
+
+	// Phase 1: Detect what columns are needed and map direct fields
+	bool need_response = false;
+	bool need_year_or_month = false;
+
 	for (auto &col_id : input.column_ids) {
 		if (col_id < bind_data.column_names.size()) {
 			string col_name = bind_data.column_names[col_id];
@@ -504,19 +509,27 @@ static unique_ptr<GlobalTableFunctionState> WaybackMachineInitGlobal(ClientConte
 			} else if (col_name == "length") {
 				bind_data.fields_needed.push_back("length");
 			} else if (col_name == "response") {
-				bind_data.fetch_response = true;
-				// Response fetching requires timestamp and original to construct download URL:
-				// https://web.archive.org/web/{timestamp}id_/{original}
-				EnsureFieldNeeded(bind_data.fields_needed, "timestamp");
-				EnsureFieldNeeded(bind_data.fields_needed, "original");
-				DUCKDB_LOG_DEBUG(context, "Will fetch response bodies");
+				need_response = true;
 			} else if (col_name == "year" || col_name == "month") {
-				// year and month need timestamp field
-				EnsureFieldNeeded(bind_data.fields_needed, "timestamp");
-			} else if (col_name == "cdx_url") {
-				// cdx_url doesn't need any CDX fields
+				need_year_or_month = true;
 			}
+			// cdx_url doesn't need any CDX fields
 		}
+	}
+
+	// Phase 2: Add dependencies based on detected needs
+	if (need_response) {
+		bind_data.fetch_response = true;
+		// Response fetching requires timestamp and original to construct download URL:
+		// https://web.archive.org/web/{timestamp}id_/{original}
+		EnsureFieldNeeded(bind_data.fields_needed, "timestamp");
+		EnsureFieldNeeded(bind_data.fields_needed, "original");
+		DUCKDB_LOG_DEBUG(context, "Will fetch response bodies");
+	}
+
+	if (need_year_or_month) {
+		// year and month columns need timestamp field
+		EnsureFieldNeeded(bind_data.fields_needed, "timestamp");
 	}
 
 	// Check if only cdx_url is selected (debug mode, fields_needed is empty and no response)

--- a/src/internet_archive.cpp
+++ b/src/internet_archive.cpp
@@ -34,6 +34,30 @@ static void EnsureFieldNeeded(vector<string> &fields_needed, const string &field
 }
 
 // ========================================
+// COLUMN DEPENDENCY MAPS
+// ========================================
+
+// Maps output column names to CDX API field names
+// Columns not in this map don't require CDX fields (e.g., cdx_url, response)
+static const std::unordered_map<string, string> COLUMN_TO_CDX_FIELD = {
+    {"url", "original"},      // CDX uses 'original' for the URL
+    {"timestamp", "timestamp"},
+    {"urlkey", "urlkey"},
+    {"mimetype", "mimetype"},
+    {"statuscode", "statuscode"},
+    {"digest", "digest"},
+    {"length", "length"},
+};
+
+// Maps columns that have dependencies on other CDX fields
+// These dependencies are added automatically when the column is selected
+static const std::unordered_map<string, vector<string>> COLUMN_DEPENDENCIES = {
+    {"response", {"timestamp", "original"}},  // Need these for download URL: /web/{timestamp}id_/{original}
+    {"year", {"timestamp"}},                   // Extracted from timestamp
+    {"month", {"timestamp"}},                  // Extracted from timestamp
+};
+
+// ========================================
 // BIND DATA AND STATE
 // ========================================
 
@@ -481,55 +505,43 @@ static unique_ptr<GlobalTableFunctionState> WaybackMachineInitGlobal(ClientConte
 	// Store projected columns
 	state->column_ids = input.column_ids;
 
-	// Rebuild fields_needed based on projection pushdown
-	// Two-phase approach: detect what's needed, then add dependencies
+	// Rebuild fields_needed based on projection pushdown using declarative maps
 	bind_data.fields_needed.clear();
+	vector<string> columns_with_dependencies;
 
-	// Phase 1: Detect what columns are needed and map direct fields
-	bool need_response = false;
-	bool need_year_or_month = false;
-
+	// Phase 1: Map columns to CDX fields and collect columns with dependencies
 	for (auto &col_id : input.column_ids) {
 		if (col_id < bind_data.column_names.size()) {
 			string col_name = bind_data.column_names[col_id];
 			DUCKDB_LOG_DEBUG(context, "Projected column: %s", col_name.c_str());
 
-			if (col_name == "url") {
-				bind_data.fields_needed.push_back("original");
-			} else if (col_name == "timestamp") {
-				bind_data.fields_needed.push_back("timestamp");
-			} else if (col_name == "urlkey") {
-				bind_data.fields_needed.push_back("urlkey");
-			} else if (col_name == "mimetype") {
-				bind_data.fields_needed.push_back("mimetype");
-			} else if (col_name == "statuscode") {
-				bind_data.fields_needed.push_back("statuscode");
-			} else if (col_name == "digest") {
-				bind_data.fields_needed.push_back("digest");
-			} else if (col_name == "length") {
-				bind_data.fields_needed.push_back("length");
-			} else if (col_name == "response") {
-				need_response = true;
-			} else if (col_name == "year" || col_name == "month") {
-				need_year_or_month = true;
+			// Check if column maps directly to a CDX field
+			auto field_it = COLUMN_TO_CDX_FIELD.find(col_name);
+			if (field_it != COLUMN_TO_CDX_FIELD.end()) {
+				bind_data.fields_needed.push_back(field_it->second);
 			}
-			// cdx_url doesn't need any CDX fields
+
+			// Check if column has dependencies
+			if (COLUMN_DEPENDENCIES.find(col_name) != COLUMN_DEPENDENCIES.end()) {
+				columns_with_dependencies.push_back(col_name);
+			}
+
+			// Special handling for response column
+			if (col_name == "response") {
+				bind_data.fetch_response = true;
+				DUCKDB_LOG_DEBUG(context, "Will fetch response bodies");
+			}
 		}
 	}
 
-	// Phase 2: Add dependencies based on detected needs
-	if (need_response) {
-		bind_data.fetch_response = true;
-		// Response fetching requires timestamp and original to construct download URL:
-		// https://web.archive.org/web/{timestamp}id_/{original}
-		EnsureFieldNeeded(bind_data.fields_needed, "timestamp");
-		EnsureFieldNeeded(bind_data.fields_needed, "original");
-		DUCKDB_LOG_DEBUG(context, "Will fetch response bodies");
-	}
-
-	if (need_year_or_month) {
-		// year and month columns need timestamp field
-		EnsureFieldNeeded(bind_data.fields_needed, "timestamp");
+	// Phase 2: Add dependencies from the declarative map
+	for (const auto &col_name : columns_with_dependencies) {
+		auto dep_it = COLUMN_DEPENDENCIES.find(col_name);
+		if (dep_it != COLUMN_DEPENDENCIES.end()) {
+			for (const auto &dep_field : dep_it->second) {
+				EnsureFieldNeeded(bind_data.fields_needed, dep_field);
+			}
+		}
 	}
 
 	// Check if only cdx_url is selected (debug mode, fields_needed is empty and no response)

--- a/test/sql/internet_archive_response_fields.test
+++ b/test/sql/internet_archive_response_fields.test
@@ -1,0 +1,109 @@
+# name: test/sql/internet_archive_response_fields.test
+# description: Test that response column selection works correctly with DISTINCT ON
+# group: [sql]
+
+# Bug fix: When response is selected, the extension must add timestamp and original
+# to fields_needed so they're included in the CDX API request (&fl= parameter).
+# These are required to construct the download URL:
+#   https://web.archive.org/web/{timestamp}id_/{original}
+# Without these fields, FetchArchivedPage returns "Missing timestamp or URL" error.
+#
+# Note: These are planner-level tests (LIMIT 0). A full regression test would need
+# network access since the error occurs at fetch time. The debug := true / cdx_url
+# approach can't be used here because projecting 'response' disables cdx_url_only mode.
+
+require web_archive
+
+# ============================================
+# BASIC RESPONSE SELECTION (SYNTAX TESTS)
+# ============================================
+
+# Test: Selecting response.body works
+statement ok
+SELECT url, response.body
+FROM wayback_machine()
+WHERE url = 'example.com'
+  AND statuscode = 200
+LIMIT 0;
+
+# Test: Selecting response struct works
+statement ok
+SELECT url, response
+FROM wayback_machine()
+WHERE url = 'example.com'
+  AND statuscode = 200
+LIMIT 0;
+
+# Test: Selecting response.error works
+statement ok
+SELECT url, response.error
+FROM wayback_machine()
+WHERE url = 'example.com'
+  AND statuscode = 200
+LIMIT 0;
+
+# ============================================
+# DISTINCT ON + RESPONSE (BUG FIX TESTS)
+# These were the failing cases before the fix
+# ============================================
+
+# Test: DISTINCT ON(year) with response.body works
+statement ok
+SELECT DISTINCT ON(year) url, timestamp, response.body
+FROM wayback_machine()
+WHERE url = 'example.com'
+  AND statuscode = 200
+LIMIT 0;
+
+# Test: DISTINCT ON(digest) with response.body works
+statement ok
+SELECT DISTINCT ON(digest) url, timestamp, response.body
+FROM wayback_machine()
+WHERE url = 'example.com'
+  AND statuscode = 200
+LIMIT 0;
+
+# Test: DISTINCT ON(year, month) with response.body works
+statement ok
+SELECT DISTINCT ON(year, month) url, timestamp, response.body
+FROM wayback_machine()
+WHERE url = 'example.com'
+  AND statuscode = 200
+LIMIT 0;
+
+# Test: DISTINCT ON with only response.body (no explicit timestamp)
+# This should still work because response selection adds timestamp to fields_needed
+statement ok
+SELECT DISTINCT ON(year) response.body
+FROM wayback_machine()
+WHERE url = 'example.com'
+  AND statuscode = 200
+LIMIT 0;
+
+# Test: DISTINCT ON with only response.body and url (no explicit timestamp)
+statement ok
+SELECT DISTINCT ON(year) url, response.body
+FROM wayback_machine()
+WHERE url = 'example.com'
+  AND statuscode = 200
+LIMIT 0;
+
+# ============================================
+# COMBINED PROJECTIONS
+# ============================================
+
+# Test: All common columns with response
+statement ok
+SELECT url, urlkey, timestamp, year, month, statuscode, mimetype, digest, length, response
+FROM wayback_machine()
+WHERE url = 'example.com'
+  AND statuscode = 200
+LIMIT 0;
+
+# Test: DISTINCT ON with all columns
+statement ok
+SELECT DISTINCT ON(year) url, urlkey, timestamp, statuscode, mimetype, digest, length, response.body
+FROM wayback_machine()
+WHERE url = 'example.com'
+  AND statuscode = 200
+LIMIT 0;


### PR DESCRIPTION
## Summary

Replaces the if/else chain in `WaybackMachineInitGlobal`'s projection pushdown with declarative data structures:

- **`COLUMN_TO_CDX_FIELD`** map: explicitly maps output column names to CDX API field names (e.g., `"url"` -> `"original"`)
- **`COLUMN_DEPENDENCIES`** map: declares implicit field dependencies (e.g., `"response"` requires `{"timestamp", "original"}` for download URL construction; `"year"`/`"month"` require `"timestamp"`)
- **`EnsureFieldNeeded`** helper: deduplicates the repeated find-then-push pattern
- **Two-phase projection**: separates column-to-field mapping (phase 1) from dependency resolution (phase 2)

This makes it straightforward to add new columns or dependencies without modifying control flow.

## Depends on

- #3 (Fix DISTINCT ON + response.body)

## Changes

- `src/internet_archive.cpp`: Refactored projection pushdown logic

## Test plan

- [ ] Existing tests still pass (no behavior change, pure refactor)