### PR TITLE
Auto-decompress gzip/zlib response bodies in wayback_machine()

### DIFF
--- a/src/include/web_archive_utils.hpp
+++ b/src/include/web_archive_utils.hpp
@@ -62,6 +62,11 @@ timestamp_t ParseCDXTimestamp(const string &cdx_timestamp);
 // Helper function to decompress gzip data using zlib
 string DecompressGzip(const char *compressed_data, size_t compressed_size);
 
+// Transparently decompress a response body if it is gzip- or zlib-compressed
+// (detected via magic bytes). Returns the input unchanged when it is not
+// compressed or when decompression fails, so callers always get usable bytes.
+string DecompressIfCompressed(const string &data);
+
 // ========================================
 // HTTP/WARC PARSING
 // ========================================

--- a/src/internet_archive.cpp
+++ b/src/internet_archive.cpp
@@ -324,7 +324,11 @@ static FetchResult FetchArchivedPage(ClientContext &context, const ArchiveOrgRec
 				response_data.append(buffer.get(), bytes_read);
 			}
 
-			result.body = response_data;
+			// The web.archive.org id_/ endpoint returns the original bytes,
+			// which preserve the upstream Content-Encoding (LinkedIn and many
+			// others serve gzip). Transparently decompress so response.body is
+			// always usable HTML without a separate gunzip step.
+			result.body = DecompressIfCompressed(response_data);
 			return result; // Success - error is empty
 
 		} catch (Exception &ex) {

--- a/src/web_archive_utils.cpp
+++ b/src/web_archive_utils.cpp
@@ -267,6 +267,55 @@ string DecompressGzip(const char *compressed_data, size_t compressed_size) {
 	return string(decompressed_buffer.begin(), decompressed_buffer.end());
 }
 
+string DecompressIfCompressed(const string &data) {
+	// Need at least the 2-byte magic to classify.
+	if (data.size() < 2) {
+		return data;
+	}
+	auto b0 = static_cast<unsigned char>(data[0]);
+	auto b1 = static_cast<unsigned char>(data[1]);
+
+	// gzip starts with 1F 8B; zlib streams start with 78 {01,9C,DA}. Plain
+	// HTML/text never starts with these byte pairs, so this is unambiguous.
+	bool is_gzip = (b0 == 0x1f && b1 == 0x8b);
+	bool is_zlib = (b0 == 0x78 && (b1 == 0x01 || b1 == 0x9c || b1 == 0xda));
+	if (!is_gzip && !is_zlib) {
+		return data;
+	}
+
+	z_stream stream;
+	memset(&stream, 0, sizeof(stream));
+
+	// windowBits = 15 + 32 enables automatic gzip/zlib header detection.
+	if (inflateInit2(&stream, 15 + 32) != Z_OK) {
+		return data;
+	}
+
+	stream.avail_in = static_cast<uInt>(data.size());
+	stream.next_in = (Bytef *)data.data();
+
+	std::vector<char> out;
+	out.reserve(data.size() * 4);
+
+	const size_t chunk_size = 32768;
+	char out_buffer[chunk_size];
+	int ret;
+	do {
+		stream.avail_out = chunk_size;
+		stream.next_out = (Bytef *)out_buffer;
+		ret = inflate(&stream, Z_NO_FLUSH);
+		if (ret != Z_OK && ret != Z_STREAM_END) {
+			// Corrupt/partial stream or false-positive magic: keep raw bytes.
+			inflateEnd(&stream);
+			return data;
+		}
+		out.insert(out.end(), out_buffer, out_buffer + (chunk_size - stream.avail_out));
+	} while (ret != Z_STREAM_END);
+
+	inflateEnd(&stream);
+	return string(out.begin(), out.end());
+}
+
 // ========================================
 // HTTP/WARC PARSING
 // ========================================


### PR DESCRIPTION
The `web.archive.org/…id_/` endpoint returns the original archived bytes, preserving upstream `Content-Encoding` (LinkedIn & many sites serve gzip). `response.body` was therefore raw gzip — callers had to gunzip before HTML parsing.

Adds `DecompressIfCompressed()`: detects gzip (`1F8B`) / zlib (`78xx`) via magic bytes, inflates with auto-detecting windowBits (`15+32`). Returns input unchanged when uncompressed or on any inflate error, so callers always get usable bytes. Wired into the wayback fetch path.

Verified: `response.body` for an archived LinkedIn company page now returns 354 KB of `<!DOCTYPE`-prefixed HTML (was raw gzip). `make test` passes (304 assertions).